### PR TITLE
fix: arch x64 instead of x86

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -32,7 +32,7 @@ const extractAsars = dir => {
 
 
 export default async (channel, mod, version) => {
-  const manifest = await fetchJson(`https://discord.com/api/updates/distributions/app/manifests/latest?platform=win&channel=${channel}&arch=x86`);
+  const manifest = await fetchJson(`https://discord.com/api/updates/distributions/app/manifests/latest?platform=win&channel=${channel}&arch=x64`);
 
   const hostVersion = manifest.full.host_version.join('.');
   version = version ?? (mod === 'host' ? manifest.full.host_version[2] : manifest.modules['discord_' + mod]?.full?.module_version);
@@ -41,7 +41,7 @@ export default async (channel, mod, version) => {
   const domain = `https://dl${channel === 'stable' ? '' : `-${channel}`}.discordapp.net`;
 
   // const downloadUrl = (mod === 'host' ? manifest : manifest.modules['discord_' + mod]).full.url;
-  const downloadUrl = mod === 'host' ? `${domain}/distro/app/${channel}/win/x86/1.0.${version}/full.distro` : `${domain}/distro/app/${channel}/win/x86/${hostVersion}/discord_${mod}/${version}/full.distro`;
+  const downloadUrl = mod === 'host' ? `${domain}/distro/app/${channel}/win/x64/1.0.${version}/full.distro` : `${domain}/distro/app/${channel}/win/x64/${hostVersion}/discord_${mod}/${version}/full.distro`;
   console.log('DOWNLOADING', mod, version, '|', downloadUrl);
 
   const outDir = join(baseOutDir, hostVersion, mod === 'host' ? 'host' : `modules`, mod === 'host' ? '' : mod);


### PR DESCRIPTION
x86 got discontinued a few months ago which would explain why no more updates are being tracked.
See: https://support.discord.com/hc/en-us/articles/17997797368471--Known-Issue-Support-for-32-bit-Windows-Operating-Systems