### PR TITLE
add missing modules

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ global.LATEST_ONLY = true;
 const modules = [
   'host',
   'desktop_core',
+  'desktop_overlay',
   'krisp',
   'dispatch',
   'utils',
@@ -18,6 +19,7 @@ const modules = [
   'overlay2',
   'game_utils',
   'voice',
+  'voice_filters',
   'vigilante',
   'rpc',
   'erlpack',


### PR DESCRIPTION
Adds the `voice_filters` and `desktop_overlay` modules that are in the [manifest](https://updates.discord.com/distributions/app/manifests/latest?platform=win&channel=canary&arch=x64).
`voice_filters` is not on stable yet but that's fine because it just ignores the download if the version of the module is not found in the manifest:
https://github.com/OpenAsar/discord-desktop-datamining/blob/af073dd0fddfd7a6f237e43d60be12731959f663/src/download.js#L38-L39